### PR TITLE
feat: add more meta tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,11 @@ type Redirect = {
     from: string
     to: string
     delay?: number
+    meta?: [
+        {
+            name: string
+            content: string
+        }
+    ]
 }
 ```

--- a/cli.js
+++ b/cli.js
@@ -28,13 +28,20 @@ if (!redirects) {
 }
 
 
-redirects.forEach(({ from, to, delay = 0 }) => {
+redirects.forEach(({ from, to, delay = 0, meta = null }) => {
 	const pathname = new URL(from, 'https://localhost').pathname
 	const directory = path.join(outputDirectory, pathname)
 
 	fs.mkdirSync(directory, { recursive: true })
+
+	let addHtml = `<meta http-equiv="Refresh" content="${delay};url=${encodeURI(to)}">`
+	if (meta) {
+		meta.forEach(({ name, content }) => {
+			addHtml += `<meta name="${name}" content="${content}">`
+		})
+	}
+
 	fs.writeFileSync(
-		path.join(directory, 'index.html'),
-		`<meta http-equiv="Refresh" content="${delay};url=${encodeURI(to)}">`
+		path.join(directory, 'index.html'), addHtml
 	)
 })

--- a/cli.js
+++ b/cli.js
@@ -35,11 +35,9 @@ redirects.forEach(({ from, to, delay = 0, meta = [] }) => {
 	fs.mkdirSync(directory, { recursive: true })
 
 	let addHtml = `<meta http-equiv="Refresh" content="${delay};url=${encodeURI(to)}">`
-	if (meta) {
-		meta.forEach(({ name, content }) => {
-			addHtml += `<meta name="${name}" content="${content}">`
-		})
-	}
+	meta.forEach(({ name, content }) => {
+		addHtml += `<meta name="${name}" content="${content}">`
+	})
 
 	fs.writeFileSync(
 		path.join(directory, 'index.html'), addHtml

--- a/cli.js
+++ b/cli.js
@@ -28,7 +28,7 @@ if (!redirects) {
 }
 
 
-redirects.forEach(({ from, to, delay = 0, meta = null }) => {
+redirects.forEach(({ from, to, delay = 0, meta = [] }) => {
 	const pathname = new URL(from, 'https://localhost').pathname
 	const directory = path.join(outputDirectory, pathname)
 

--- a/example-array.json
+++ b/example-array.json
@@ -14,6 +14,16 @@
     {
         "from": "/linkedin",
         "to": "https://www.linkedin.com/in/iamandrewluca/",
-        "delay": 5
+        "delay": 5,
+        "meta": [
+          {
+            "name": "og:title",
+            "content": "Example Title for Redirect"
+          },
+          {
+            "name": "og:image",
+            "content": "https://via.placeholder.com/150"
+          }
+        ]
     }
 ]


### PR DESCRIPTION
Allows adding meta tags to redirects, so that link embeds (og:tags) can be used for SEO and sharing